### PR TITLE
[style] Redesign : 헤더 및 바텀바 크기 변경

### DIFF
--- a/src/components/Layout/Body/defaultBody.tsx
+++ b/src/components/Layout/Body/defaultBody.tsx
@@ -11,7 +11,7 @@ interface DefaultBodyProps {
 const DefaultBody: React.FC<DefaultBodyProps> = ({ hasHeader, children }) => {
     
     
-    const pt = hasHeader? " pt-[108px]" : "";
+    const pt = hasHeader? " pt-[80px]" : "";
 
     return (
        

--- a/src/components/Layout/BottomNav/BottomNav.tsx
+++ b/src/components/Layout/BottomNav/BottomNav.tsx
@@ -22,7 +22,7 @@ export default function BottomNav({ activeIndex = 0 }: BottomNavProps) {
             className="fixed bottom-0  bg-white right-0 w-full left-1/2 -translate-x-1/2 max-w-[500px]"
             style={{
                 boxShadow: '0px -2px 15px 5px rgba(0, 0, 0, 0.07)', // 얇고 가벼운 그림자
-                height: '82px', // 컴팩트한 높이
+                height: '62px', // 컴팩트한 높이
             }}
         >
             <ul className="flex justify-around items-center h-full">

--- a/src/components/Layout/header/Header.tsx
+++ b/src/components/Layout/header/Header.tsx
@@ -53,7 +53,7 @@ const Header = ({ children }: HeaderProps) => {
         <header
             className="
                 flex items-end justify-between
-                px-[20px] h-[108px] bg-white fixed top-0
+                px-[20px] h-[80px] bg-white fixed top-0
                 left-1/2 -translate-x-1/2 right-0 z-10
                 w-full
                 max-w-[500px] 


### PR DESCRIPTION
## 🛠 구현 사항
- 헤더 108px -> 80px
- 바텀바 82px -> 62px
