### PR TITLE
[refact] 레이아웃 구조 변경 : 현재시간NAV->상위컴포넌트로 이동

### DIFF
--- a/src/app/(auth-required)/roomstatus/components/roomItem.tsx
+++ b/src/app/(auth-required)/roomstatus/components/roomItem.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { roomItemProps } from "../interfaces/roomItem_interface";
 import RoomItemDetail from "./roomItemDetail";
 import { Lecture } from "../interfaces/page_interface";
-import { TIMETABLE_GAP, TIMETABLE_LENGTH, TIMETABLE_WIDTH } from "../constants/timeTableSize";
+import { TIMETABLE_GAP, TIMETABLE_LENGTH, TIMETABLE_WIDTH } from "../constants/timeTableData";
 
 const RoomItem: React.FC<roomItemProps> = ({ RoomName, LectureList, RoomStatusList, BoundaryList }) => {
 
@@ -118,7 +118,7 @@ const RoomItem: React.FC<roomItemProps> = ({ RoomName, LectureList, RoomStatusLi
                             onTouchStart={()=>onClickTimeLine(index)}
                             onTouchEnd={()=>onClickTimeLine(-1)}
                             style={{ width: `${TIMETABLE_WIDTH}px`, height: `${TIMETABLE_WIDTH*1.5}px` }}
-                            className={`relative shrink-0 rounded-[3px] ${activeIndexList[index] ? RoomStatusList[index] === 1 ? 'bg-[#17659c]' : 'bg-[#212121]' : status ? 'bg-[#0D99FF]' : 'bg-[#EBF0F7]'}`}
+                            className={`relative shrink-0 rounded-[1.5px] ${activeIndexList[index] ? RoomStatusList[index] === 1 ? 'bg-[#17659c]' : 'bg-[#212121]' : status ? 'bg-[#0D99FF]' : 'bg-[#EBF0F7]'}`}
                         ><RoomItemDetail isActive={getIsActive(index)} lecture={touchedLecture} /></button>
                     ))}
                 </div>

--- a/src/app/(auth-required)/roomstatus/constants/timeTableData.tsx
+++ b/src/app/(auth-required)/roomstatus/constants/timeTableData.tsx
@@ -1,0 +1,5 @@
+export const TIMETABLE_LENGTH = 36;
+export const TIMETABLE_GAP = 2.5;
+export const TIMETABLE_WIDTH = 12;
+export const MINHOUR = 9;
+export const MAXHOUR = 18;

--- a/src/app/(auth-required)/roomstatus/constants/timeTableSize.tsx
+++ b/src/app/(auth-required)/roomstatus/constants/timeTableSize.tsx
@@ -1,3 +1,0 @@
-export const TIMETABLE_LENGTH = 36;
-export const TIMETABLE_GAP = 2.5;
-export const TIMETABLE_WIDTH = 7.5;

--- a/src/app/(auth-required)/roomstatus/interfaces/currentTimePointer_interface.tsx
+++ b/src/app/(auth-required)/roomstatus/interfaces/currentTimePointer_interface.tsx
@@ -1,0 +1,7 @@
+export interface CurrentTimePointerProps {
+    minHour:number, maxHour:number, 
+    widthOfBlock: number, gapBetweenBlocks: number,
+    numOfBlocks: number,
+    refOfParent: React.RefObject<HTMLDivElement>, 
+    setShowNav: React.Dispatch<React.SetStateAction<string | null>>
+}

--- a/src/app/(auth-required)/roomstatus/page.tsx
+++ b/src/app/(auth-required)/roomstatus/page.tsx
@@ -10,7 +10,8 @@ import RoomItem from "./components/roomItem";
 import CurrentTimePointer from "./components/currentTimePointer";
 import { Lecture, LectureDict } from "./interfaces/page_interface";
 import DefaultBody from "@/components/Layout/Body/defaultBody";
-import { TIMETABLE_GAP, TIMETABLE_LENGTH, TIMETABLE_WIDTH } from "./constants/timeTableSize";
+import { MAXHOUR, MINHOUR, TIMETABLE_GAP, TIMETABLE_LENGTH, TIMETABLE_WIDTH } from "./constants/timeTableData";
+import { getMarginLeft } from "./utils/timePointerUtils";
 
 const RoomStatus: FC = () => {
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -25,8 +26,10 @@ const RoomStatus: FC = () => {
     null,
   ]);
 
+  //자식 요소에서 가져오는 props
+  const [showNav, setShowNav] = useState(null);
   
-   useEffect(() => {
+  useEffect(() => {
     const date = new Date();
     const day = `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
 
@@ -144,6 +147,17 @@ const RoomStatus: FC = () => {
     return [timeTable, boundaryTable];
   };
 
+  const scrollToNow = ( direction: number ) => {
+      const currentTime = new Date();
+      if( currentTime.getHours() < MINHOUR || currentTime.getHours() >= MAXHOUR){
+          scrollRef.current?.scrollTo({ left: 0, behavior: "smooth" });
+      } else if (!direction){
+          scrollRef.current?.scrollTo({ left: getMarginLeft() - window.innerWidth/2, behavior: "smooth" });
+      } else{
+          scrollRef.current?.scrollTo({ left: getMarginLeft() + window.innerWidth/2, behavior: "smooth" });
+      }
+  }
+
   return (
     <Suspense>
       <div className={"w-full h-full"}>
@@ -194,16 +208,21 @@ const RoomStatus: FC = () => {
                 }}
               />
             </div>
-            
+
+            <div className={"flex items-end w-full h-[24px] bg-[rgba(0,0,0,0)] z-40 relative " + (showNav === "left" ?  "justify-start" : "justify-end")}>
+              { showNav === "left"  && <button onClick={()=>{scrollToNow(0);}} className="text-[#FFB300] text-sm z-40 translate-y-full"><span className="text-sr text-[#FFB300] ml-[2px]">◀</span> 현재 시간</button> }
+              { showNav === "right" && <button onClick={()=>{scrollToNow(1);}} className="text-[#FFB300] text-sm z-40 translate-y-full">현재 시간 <span className="text-sr text-[#FFB300] ml-[2px]">▶</span> </button> }
+            </div>
+
             <div 
               ref={scrollRef}
               id="scrollbar-hidden" 
-              className="overflow-x-scroll relative mt-[24px] h-fit" 
+              className="overflow-x-scroll relative h-fit" 
             >
               <CurrentTimePointer
-                minHour={9} maxHour={18}
+                minHour={MINHOUR} maxHour={MAXHOUR}
                 widthOfBlock={TIMETABLE_WIDTH} gapBetweenBlocks={TIMETABLE_GAP} numOfBlocks={TIMETABLE_LENGTH}
-                refOfParent={scrollRef}
+                refOfParent={scrollRef} setShowNav={setShowNav}
               />
 
               {roomStatus[floor - 1] &&

--- a/src/app/(auth-required)/roomstatus/utils/timePointerUtils.tsx
+++ b/src/app/(auth-required)/roomstatus/utils/timePointerUtils.tsx
@@ -1,0 +1,11 @@
+import { MAXHOUR, MINHOUR, TIMETABLE_GAP, TIMETABLE_LENGTH, TIMETABLE_WIDTH } from "../constants/timeTableData";
+
+export const getMarginLeft = () => {        
+    const currentTime = new Date();
+    const currentHour = currentTime.getHours();
+    const currentMinute = currentTime.getMinutes();
+    const totalMinutes = (currentHour - MINHOUR) * 60 + currentMinute;
+    const totalWidth = TIMETABLE_LENGTH * (TIMETABLE_WIDTH + TIMETABLE_GAP);
+    const marginLeft = (totalWidth / ((MAXHOUR - MINHOUR) * 60)) * totalMinutes;
+    return Math.floor(marginLeft);
+}


### PR DESCRIPTION
## 🛠 구현 사항
- 레이아웃 안정성 강화
    - (기존) 현재시간 이동을 타임테이블 내에서 실행 -> (*변경) 현재시간 이동을 상위 컴포넌트에서 실행 
    - **Y방향 스크롤** 시, 안내 NAV위치가 비정상적인 구조를 해결하기 위함

## 📚 기타
- currentTimePointer 인터페이스 : 별도 파일로 구분
- utils : 강의실 현황에서, 현재 시간 좌측 margin구하는 함수 공통 유틸로 구분 
