### PR TITLE
fix(QA 2): 메인 경유하면 버튼 안먹는 이슈 해결

### DIFF
--- a/src/app/(auth-required)/main/page.tsx
+++ b/src/app/(auth-required)/main/page.tsx
@@ -17,7 +17,6 @@ import { fetchClient } from '@/api/clients/fetchClient';
 import RoomItemHourly from '../roomstatus/components/roomItemHourly';
 import { Lecture, LectureDict } from '../roomstatus/interfaces/page_interface';
 import { TIMETABLE_LENGTH } from '../roomstatus/constants/timeTableData';
-import clsx from 'clsx';
 import PageBar from '@/components/Layout/pageBar';
 
 const timeAgo = (timestamp: string): string => {
@@ -213,6 +212,7 @@ const MainPage: FC = () => {
           🚧 이곳은 개발 서버입니다.
         </div>
       )}
+      
 
       {/* <ShadowBox className="pl-[19px] pr-[14px] pt-[28px] pb-[25px] h-[213px]">
         <div>

--- a/src/app/(auth-required)/vote/page.tsx
+++ b/src/app/(auth-required)/vote/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 import { useRouter } from 'next/navigation';
 import { useContext, useState, useEffect, useRef } from 'react';
-import BottomNav from '@/components/Layout/BottomNav/BottomNav';
 import { AuthContext } from '@/context/AuthContext';
 import { GetVoteData } from '@/api/vote/getVoteData';
 import { PostVoting } from '@/api/vote/postVoting';
@@ -13,10 +12,8 @@ import Title from '@/components/common/title';
 import clsx from 'clsx';
 
 export default function Vote() {
-  const router = useRouter();
   const authContext = useContext(AuthContext);
   const chatBoxRef = useRef<HTMLDivElement | null>(null);
-  const { Auth } = authContext;
   const [voteList, setVoteList] = useState<any>([]); // 초기값은 any로 두었지만 나중에 타입을 정의할 수 있음
   const [page, setPage] = useState<number>(0);
   const [isLoading, setIsLoading] = useState<boolean>(false);

--- a/src/components/calendar/DateCalendar.tsx
+++ b/src/components/calendar/DateCalendar.tsx
@@ -128,18 +128,25 @@ export default function DateCalendar() {
     fetchCalendarData();
   }, [today]);
 
-  useEffect(() => {
-    document.addEventListener('click', e => {
-      e.preventDefault();
-      const target = e.target as HTMLElement;
-      if (!target.id.includes('calendar-day')) {
+  // 2) 전역 클릭 리스너 교체
+    useEffect(() => {
+      function handleDocClick(e: MouseEvent) {
+        // 기본 동작 막지 않음! (preventDefault 제거)
+        const el = e.target as HTMLElement | null;
+        // 달력 날짜 셀 내부를 클릭한 경우는 유지
+        if (el && el.closest('[data-calendar-day]')) return;
         setSelectedDate(null);
       }
-    });
-    return () => {
-      document.removeEventListener('click', () => null);
-    };
-  }, []);
+
+      // 버블 단계에서만 가볍게 처리 (capture 불필요)
+      document.addEventListener('click', handleDocClick);
+
+      // 정확한 cleanup (같은 참조로 제거)
+      return () => {
+        document.removeEventListener('click', handleDocClick);
+      };
+    }, []);
+
 
   return (
     <ShadowBox>
@@ -268,7 +275,7 @@ export default function DateCalendar() {
                 >
                   {date !== null && (
                     <div className="relative flex flex-col items-center">
-                      <div
+                      {/* <div
                         id="calendar-day"
                         onClick={() =>
                           onClickChangeDate(date, index - emptyDates.length + 1)
@@ -292,7 +299,17 @@ export default function DateCalendar() {
                         )}
                       >
                         {date.date.format('D')}
+                      </div> */}
+                      <div
+                        data-calendar-day
+                        onClick={() =>
+                          onClickChangeDate(date, index - emptyDates.length + 1)
+                        }
+                        className={clsx(/* ... */)}
+                      >
+                        {date.date.format('D')}
                       </div>
+
                       <div className="flex mt-[5px] h-[6px] gap-[3px]">
                         {calendarData_fetched &&
                           calendarData_fetched[index - emptyDates.length + 1] &&


### PR DESCRIPTION
### 🔥 작업 내용
- 메인 경유하면 버튼 클릭 안먹는 이슈 해결
-> 메인 - 캘린더 코드에 e.preventDefault() 를 문서 전체 클릭에 걸어 해당 문제가 발생한 것으로 보입니다.

### 🤔 추후 작업 사항
- 버튼 정상작동 확인 및 나머지 이슈 해결

### 🔗 이슈


### 📸 피그마 스크린샷 or 기능 GIF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 해당 없음
- 버그 수정
  - 달력에서 날짜 셀 외부를 클릭할 때 선택 해제 동작의 안정성과 일관성을 개선하고 이벤트 정리 문제를 수정했습니다.
- 리팩터
  - 사용되지 않는 의존성 및 import를 정리하고 불필요한 라우터·컨텍스트 참조를 제거했습니다.
- 스타일
  - 사소한 포맷팅 및 공백 조정으로 가독성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->