### PR TITLE
[fix] 티켓팅  수정사항

### DIFF
--- a/src/app/(auth-required)/ticketing/[eventId]/page.tsx
+++ b/src/app/(auth-required)/ticketing/[eventId]/page.tsx
@@ -335,7 +335,7 @@ export default function SnackDetail() {
                   <div>장소: {eventData.locationInfo}</div>
                   <div>대상: {eventData.target}</div>
                   <div>수량: {eventData.quantity}</div>
-                  <div>티켓팅 가능 시간: {formatDateTimeWithDay(eventData.eventTime)}</div>
+                  <div>티켓팅 시작 시간: {formatDateTimeWithDay(eventData.eventTime)}</div>
                   <div className="text-black/50 self-center mt-[18px]">{eventData.description}</div>
                   <a href={eventData.promotionLink} className="text-[#0D99FF] mt-[18px]">학생회 간식나눔 홍보글 링크</a>
                   <div className="self-end text-[#AEAEAE]">문의: {eventData.inquiryNumber}</div>

--- a/src/app/(auth-required)/ticketing/page.tsx
+++ b/src/app/(auth-required)/ticketing/page.tsx
@@ -114,7 +114,7 @@ const TicketingPage: FC = () => {
         {snacks.map((snack) => (
           <div
             key={snack.eventId}
-            className="relative rounded-[15px] py-[29px] px-4 flex flex-col
+            className="relative rounded-[15px] py-[29px] flex flex-col
                 shadow-[0px_5px_13.3px_4px_rgba(212,212,212,0.59)]
                 cursor-pointer "
             onClick={() => {if (snack.eventStatus !== 'ENDED') { router.push(`/ticketing/${snack.eventId}`)}
@@ -124,20 +124,21 @@ const TicketingPage: FC = () => {
               {snack.eventStatus === 'ENDED' && (
                 <div className="absolute inset-0 bg-[rgba(0,0,0,0.18)] rounded-[15px] z-20 cursor-not-allowed" />
               )}
-            <div className="flex items-start mb-[13px]">
-              <p className="font-semibold text-[14px]">{snack.eventTitle}</p>
-              <p className="text-[25px] text-[#0D99FF] mt-[-17px]"> •</p>
-            </div>
-            <div className="flex flex-row justify-center items-start">
-              <div className="flex flex-col justify-start">
-                <div className="mt-[5px] text-[12px] text-black">{formatDateTimeWithDay(snack.eventEndTime)}</div>
-                <div className="text-[12px] text-black">{snack.locationInfo}</div>
-                <div className="text-[12px] text-black">{snack.quantity}명</div>
-                <div className="text-[12px] text-[#0D99FF]">티켓팅 오픈: {formatDateTimeWithDay(snack.eventTime)}</div>
+            <div className="flex flex-col items-center px-4">
+              <div className="flex items-start mb-[13px] w-full">
+                <p className="font-semibold text-[14px]">{snack.eventTitle}</p>
+                <p className="text-[25px] text-[#0D99FF] mt-[-17px]"> •</p>
               </div>
-              <img src={snack.eventImageUrl} className="w-[93px] h-[93px] border border-1 border-[#d4d4d4] rounded-[10px] p-2 mr-[14px] ml-[23px]"></img>
+              <div className="flex flex-row justify-center items-start w-full">
+                <div className="flex flex-col justify-start w-full">
+                  <div className="mt-[5px] text-[12px] text-black">{formatDateTimeWithDay(snack.eventEndTime)}</div>
+                  <div className="text-[12px] text-black">{snack.locationInfo}</div>
+                  <div className="text-[12px] text-black">{snack.quantity}명</div>
+                  <div className="text-[12px] text-[#0D99FF]">티켓팅 오픈: {formatDateTimeWithDay(snack.eventTime)}</div>
+                </div>
+                <img src={snack.eventImageUrl} className="w-[93px] h-[93px] border border-1 border-[#d4d4d4] rounded-[10px] p-2 ml-[23px]"></img>
+              </div>
             </div>
-            
           </div>
         ))}
       </div>

--- a/src/components/modals/ticketing/CancelModal.tsx
+++ b/src/components/modals/ticketing/CancelModal.tsx
@@ -33,7 +33,7 @@ const CancelModal: FC<CancelModalProps> = ({
 
 
   return (
-    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex justify-center items-center">
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-[200] flex justify-center items-center">
       <div className="bg-white w-[75%] max-w-[400px] rounded-xl shadow-lg p-7 relative text-center">
 
         <p className="text-[14px] font-medium mb-[26px] text-[#212121]">

--- a/src/components/modals/ticketing/SignModal.tsx
+++ b/src/components/modals/ticketing/SignModal.tsx
@@ -70,7 +70,7 @@ const SignModal: FC<SignModalProps> = ({ onClose, eventId }) => {
             <p className="text-center text-[12px] text-black/50 mt-2 mb-4">수령 확인 및 본인 확인 용도로 사용됩니다.</p>
         </div>
         {/* 버튼 영역 */}
-        <div className="fixed bottom-0 left-0 w-full px-4 bg-white pb-[35px] flex flex-col items-center">
+        <div className="fixed bottom-[50px] left-0 w-full px-4 bg-white pb-[35px] flex flex-col items-center">
           <button
             className="mt-3 w-full h-[50px] bg-[#EBF0F7] text-[#808080] rounded-[5px] text-[18px] font-medium max-w-[500px]"
             onClick={handleClear}


### PR DESCRIPTION
### 🔥 작업 내용
- 간식나눔 이벤트 페이지 시작 시간 문구 수정
- 서명하기 부분 하단 버튼 수정
- 티켓팅 취소부분 z index 수정
- 티켓팅 리스트에서 제목 위치 틀어지는 문제(웹)

### 🤔 추후 작업 사항
- 티켓팅 완료했을 경우 하단 버튼 문구 수정 (백엔드 작업 기다려야함)

### 🔗 이슈
- #280 

### 📸 피그마 스크린샷 or 기능 GIF
<img width="526" height="939" alt="image" src="https://github.com/user-attachments/assets/d47b00dd-16eb-41c4-baab-4b1a3cc0345c" />
<img width="509" height="936" alt="image" src="https://github.com/user-attachments/assets/79c891c0-b61d-4845-b8eb-0e3a24bd61e0" />
웹:
<img width="466" height="914" alt="image" src="https://github.com/user-attachments/assets/9f981be1-5fda-4f73-a650-02f4a80dd724" />
모바일:
<img width="419" height="865" alt="image" src="https://github.com/user-attachments/assets/fb127db9-b877-4e57-8afd-176a8dc6160e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 이벤트 상세 정보의 시간 라벨을 “티켓팅 시작 시간”으로 변경해 용어 일관성 개선.
  - 티켓 목록 카드 레이아웃 개편: 좌측 정보 정렬, 우측 이미지 배치, 가로 여백/폭 정돈으로 가독성 및 시각적 균형 향상.
  - 카드 헤더 정렬 및 장식 요소 정비. 판매 종료 오버레이 동작은 동일하며 내부 구조만 재정리.
  - 취소 모달 z-index 상향으로 다른 요소 위 안정적 노출.
  - 서명 모달 하단 고정 버튼 영역을 50px 상향해 터치 접근성 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->