### PR TITLE
[fix] 글 작성 완료하면 이전페이지로 이동

### DIFF
--- a/src/app/(auth-required)/boards/[boardName]/create/page.tsx
+++ b/src/app/(auth-required)/boards/[boardName]/create/page.tsx
@@ -98,7 +98,7 @@ const CreatePostPage = () => {
         const newPath = `/boards/${boardName}?postId=${postId}`;
         router.push(newPath);
       }
-
+      router.back();
       previewImages.forEach(url => URL.revokeObjectURL(url));
       setPreviewImages([]);
       setPostImages([]);


### PR DESCRIPTION
### 🔥 작업 내용
- [[fix] 글 작성 완료하면 이전페이지로 이동](https://github.com/CodIN-INU/front-end/commit/cea613736faa7909e67ad529aded7062d6749422)

### 🤔 추후 작업 사항
- 

### 🔗 이슈
- 

### 📸 피그마 스크린샷 or 기능 GIF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Refactor
  * 게시물 작성 완료 후 이동 경로가 생성된 게시물 상세 페이지로의 자동 이동에서 직전 화면으로 돌아가는 동작으로 변경되었습니다. 작성 후 곧바로 이전 목록이나 컨텍스트로 복귀할 수 있어 연속 작업이 쉬워집니다. 임시 미리보기 해제 및 입력 값 초기화 등 작성 후 정리 동작은 그대로 유지됩니다. 예상치 못한 페이지 전환으로 인한 맥락 이탈을 줄이는 데 도움이 됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->