### PR TITLE
[fix] 티켓 취소시간 수정

### DIFF
--- a/src/app/(auth-required)/ticketing/[eventId]/page.tsx
+++ b/src/app/(auth-required)/ticketing/[eventId]/page.tsx
@@ -360,7 +360,7 @@ export default function SnackDetail() {
                   <div className="font-bold text-[13px] mt-1">수령 안내</div>
                   <div>
                     • 티켓팅 성공 시 발급된 <span className="text-[#0D99FF]">간식나눔 교환권과 학생증</span>을 제시해야 수령 가능합니다.  <br />
-                    • <span className="text-[#0D99FF]">간식나눔 시작 후 ○분 내</span> 미수령 시, 해당 티켓은 자동 취소되고 현장 배부로 전환됩니다.
+                    • <span className="text-[#0D99FF]">간식나눔 시작 후 30분 내</span> 미수령 시, 해당 티켓은 자동 취소되고 현장 배부로 전환됩니다.
                   </div>
                   <div className="font-bold text-[13px] mt-1">양도·거래 금지</div>
                   <div>


### PR DESCRIPTION
### 🔥 작업 내용
- [[fix] 티켓 취소시간 수정](https://github.com/CodIN-INU/front-end/commit/bdd7f7265a6e11dbd5b867b2b8a1edb99e7c50ba)

### 🤔 추후 작업 사항
- 

### 🔗 이슈
- #280 

### 📸 피그마 스크린샷 or 기능 GIF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 수령 안내 섹션의 미수령 시 안내 문구를 구체화했습니다. 기존의 “간식나눔 시작 후 ○분 내”를 “간식나눔 시작 후 30분 내”로 명시하여 안내 내용을 명확히 제공합니다.
  - 화면 내 동작이나 기능 변화는 없으며, 표기 수정으로 이용자가 수령 가능 시간을 즉시 파악할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->