### PR TITLE
[fix] 티켓팅 마감시간 수정

### DIFF
--- a/src/app/(auth-required)/ticketing/result/TicketingResultInner.tsx
+++ b/src/app/(auth-required)/ticketing/result/TicketingResultInner.tsx
@@ -23,6 +23,10 @@ export default function TicketingResultInner() {
   const [isLoading, setIsLoading] = useState(true);
   const [ticket, setTicket] = useState<TicketInfo>();
 
+  const extendedEndTime = new Date(new Date(ticket.eventEndTime).getTime() + 30 * 60 * 1000);
+
+
+
   useEffect(() => {
     if (!status || !eventId) {
       router.replace('/');
@@ -90,7 +94,7 @@ export default function TicketingResultInner() {
 
                 <div className="fixed bottom-[50px] left-0 w-full px-4 bg-white pb-[35px] flex flex-col items-center">
                   <div className="text-[11px] text-center text-[#FF2525] font-normal">
-                    {formatDateTimeWithDay(ticket.eventEndTime)}까지 오지 않으면
+                    {formatDateTimeWithDay(extendedEndTime.toISOString())}까지 오지 않으면
                     티켓이 자동 취소돼요.
                     <br /> 그 전에 꼭 방문해 주세요!
                   </div>


### PR DESCRIPTION
### 🔥 작업 내용
- 

### 🤔 추후 작업 사항
- 

### 🔗 이슈
- 

### 📸 피그마 스크린샷 or 기능 GIF
(작업 내역 스크린샷)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 티켓 결과 화면의 자동 취소 안내가 업데이트되었습니다. 이제 이벤트 종료 시각에 30분의 유예 시간을 더한 마감 시각이 표시되어 실제 취소 처리 시점과 일치하는 안내를 제공합니다. 남은 시간 안내가 더 명확해졌으며, 날짜/요일 형식으로 일관되게 노출됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->