### PR TITLE
[fix[ 마감시간 수정

### DIFF
--- a/src/app/(auth-required)/ticketing/result/TicketingResultInner.tsx
+++ b/src/app/(auth-required)/ticketing/result/TicketingResultInner.tsx
@@ -94,7 +94,7 @@ export default function TicketingResultInner() {
 
                 <div className="fixed bottom-[50px] left-0 w-full px-4 bg-white pb-[35px] flex flex-col items-center">
                   <div className="text-[11px] text-center text-[#FF2525] font-normal">
-                    {formatDateTimeWithDay(extendedEndTime.toISOString())}까지 오지 않으면
+                    {formatDateTimeWithDay(ticket.eventEndTime)} 30분 전까지 오지 않으면
                     티켓이 자동 취소돼요.
                     <br /> 그 전에 꼭 방문해 주세요!
                   </div>


### PR DESCRIPTION
### 🔥 작업 내용
- 

### 🤔 추후 작업 사항
- 

### 🔗 이슈
- 

### 📸 피그마 스크린샷 or 기능 GIF
(작업 내역 스크린샷)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 대기 상태 화면에서 표시되던 날짜/시간이 실제 행사 종료 시각과 어긋나 보이던 문제를 수정했습니다. 이제 안내 문구는 실제 종료 시각을 기준으로 정확하게 표시되며, “30분 전까지 오지 않으면 …” 메시지는 기존과 동일하게 유지됩니다. 이로써 시간 정보의 정확성과 일관성이 개선되어, 티켓 수령 가능 시간에 대한 혼선을 줄이고 계획 수립이 쉬워졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->