### PR TITLE
[fix] 마감시간 수정

### DIFF
--- a/src/app/(auth-required)/ticketing/result/TicketingResultInner.tsx
+++ b/src/app/(auth-required)/ticketing/result/TicketingResultInner.tsx
@@ -23,7 +23,7 @@ export default function TicketingResultInner() {
   const [isLoading, setIsLoading] = useState(true);
   const [ticket, setTicket] = useState<TicketInfo>();
 
-  const extendedEndTime = new Date(new Date(ticket.eventEndTime).getTime() + 30 * 60 * 1000);
+  
 
 
 
@@ -44,6 +44,7 @@ export default function TicketingResultInner() {
           `/ticketing/event/participation/${eventId}`
         );
         if (!ignore) setTicket(res.data);
+        
       } catch (err) {
         console.error(err);
       } finally {
@@ -54,7 +55,7 @@ export default function TicketingResultInner() {
       ignore = true;
     };
   }, [eventId]);
-
+const extendedEndTime = new Date(new Date(ticket.eventEndTime).getTime() + 30 * 60 * 1000);
   if (!status || !eventId) return null;
   if (isLoading && !ticket) return <div />;
 
@@ -94,7 +95,7 @@ export default function TicketingResultInner() {
 
                 <div className="fixed bottom-[50px] left-0 w-full px-4 bg-white pb-[35px] flex flex-col items-center">
                   <div className="text-[11px] text-center text-[#FF2525] font-normal">
-                    {formatDateTimeWithDay(ticket.eventEndTime)} 30분 전까지 오지 않으면
+                    {formatDateTimeWithDay(extendedEndTime.toISOString())}까지 오지 않으면
                     티켓이 자동 취소돼요.
                     <br /> 그 전에 꼭 방문해 주세요!
                   </div>


### PR DESCRIPTION
### 🔥 작업 내용
- [fix] 마감시간 수정 최종

### 🤔 추후 작업 사항
- 

### 🔗 이슈
- 

### 📸 피그마 스크린샷 or 기능 GIF
(작업 내역 스크린샷)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 티켓팅 결과 화면의 마감 안내가 기존 이벤트 종료 시각 대신 “종료 후 30분” 기준으로 표시됩니다. 업데이트된 문구로 실제 유효 시간을 더 명확하게 파악할 수 있어 혼선을 줄입니다. 화면 전반에서 표기가 일관되게 노출되어 계획 수립이 쉬워졌습니다. 기존 대비 최대 30분의 추가 여유가 반영되어, 늦게 접속한 경우에도 남은 처리 가능 시간을 직관적으로 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->