### PR TITLE
[fix] 티켓팅 취소시간 수정

### DIFF
--- a/src/app/(auth-required)/ticketing/result/TicketingResultInner.tsx
+++ b/src/app/(auth-required)/ticketing/result/TicketingResultInner.tsx
@@ -22,7 +22,6 @@ export default function TicketingResultInner() {
   const [showSignModal, setShowSignModal] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [ticket, setTicket] = useState<TicketInfo>();
-
   
 
 
@@ -54,12 +53,14 @@ export default function TicketingResultInner() {
       ignore = true;
     };
   }, [eventId]);
+  
 
   if (!status || !eventId) return null;
   if (isLoading && !ticket) return <div />;
 
   switch (status) {
     case 'success':
+      const extendedEndTime = new Date(new Date(ticket.eventEndTime).getTime() + 30 * 60 * 1000);
       return (
         <Suspense>
           <Header
@@ -94,7 +95,7 @@ export default function TicketingResultInner() {
 
                 <div className="fixed bottom-[50px] left-0 w-full px-4 bg-white pb-[35px] flex flex-col items-center">
                   <div className="text-[11px] text-center text-[#FF2525] font-normal">
-                    {formatDateTimeWithDay(ticket.eventEndTime)} 이후 30분까지 오지 않으면
+                    {formatDateTimeWithDay(extendedEndTime.toISOString())}까지 오지 않으면
                     티켓이 자동 취소돼요.
                     <br /> 그 전에 꼭 방문해 주세요!
                   </div>


### PR DESCRIPTION
### 🔥 작업 내용
- [[fix] 티켓팅 취소시간 수정](https://github.com/CodIN-INU/front-end/commit/299e97d26c413a0da6d82d287e80e00d5163d02c)

### 🤔 추후 작업 사항
- 

### 🔗 이슈
- 

### 📸 피그마 스크린샷 or 기능 GIF
(작업 내역 스크린샷)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신규 기능
  * 티켓팅 결과 화면(성공 상태)에서 이벤트 종료 시각에 30분의 추가 여유 시간이 반영됩니다. 표시되는 종료 시간과 만료 안내 문구가 이에 맞게 업데이트됩니다. 본 변경은 안내 텍스트와 시간 표시에 한정되며, 결제·입장 등 다른 기능 흐름과 타임라인/알림 동작은 기존과 동일합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->