### PR TITLE
[fix] 종료된 이벤트도 확인가능하도록 수정

### DIFF
--- a/src/app/admin/ticketing/page.tsx
+++ b/src/app/admin/ticketing/page.tsx
@@ -131,14 +131,14 @@ const TicketingPage: FC = () => {
                 cursor-pointer
               "
               onClick={() => {
-                if (snack.eventStatus !== 'ENDED') {
+                
                   router.push(`/admin/ticketing/${snack.eventId}`);
-                }
+                
               }}
             >
               {/* 오버레이: 이벤트 종료 시 */}
               {snack.eventStatus === 'ENDED' && (
-                <div className="absolute inset-0 bg-[rgba(0,0,0,0.18)] rounded-[15px] z-20 cursor-not-allowed" />
+                <div className="absolute inset-0 bg-[rgba(0,0,0,0.18)] rounded-[15px] z-20 " />
               )}
             <img src={snack.eventImageUrl} className="w-[93px] h-[93px] border border-[#d4d4d4] rounded-[10px] p-2 mr-[14px]"></img>
             <div className="flex flex-col items-start">


### PR DESCRIPTION
### 🔥 작업 내용
- [[fix] 관리자 페이지 종료된 이벤트도 확인가능하도록 수정](https://github.com/CodIN-INU/front-end/commit/15936a2397ac6e3e605ee1d1fdf06a38d92d6166)

### 🤔 추후 작업 사항
- 

### 🔗 이슈
- 

### 📸 피그마 스크린샷 or 기능 GIF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새 기능
  - 관리자 티켓팅 페이지에서 스낵 상태와 관계없이 카드 클릭 시 항상 이벤트 상세 페이지로 이동합니다.
- 스타일
  - 종료된 이벤트 카드의 오버레이는 유지되며, ‘금지’ 커서 표시가 제거되어 커서는 기본 모양으로 노출됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->