### PR TITLE
fix: 매니저계정은 단과대 학과 정보 체크 안하도록 변경

### DIFF
--- a/src/features/main/pages/MainPage.tsx
+++ b/src/features/main/pages/MainPage.tsx
@@ -31,7 +31,7 @@ const MainPage: FC<MainPageProps> = ({ belowFoldContent }) => {
         user.college !== undefined &&
         (user.college == null || String(user.college).trim() === '');
       const nameTooShort = (user.name?.length ?? 0) <= 1;
-      if (departmentEmpty || collegeEmpty || nameTooShort) {
+      if ((departmentEmpty || collegeEmpty || nameTooShort) && user.userRole !== 'MANAGER') {
         alert('단과대 및 학과 등록 또는 올바른 정보인지 확인해주세요.');
         router.push(EDIT_PAGE_PATH);
       }


### PR DESCRIPTION
### 🔥 작업 내용
- 매니저계정은 단과대 학과 정보 체크 안하도록 변경

### 🤔 추후 작업 사항
- 간식나눔 학과 선택창 -> 유저정보 확인 및 수정하러가기버튼으로 변경

### 🔗 이슈
- #366 

### 📸 피그마 스크린샷 or 기능 GIF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 매니저 권한을 가진 사용자가 페이지 유효성 검사로 인한 경고 및 리다이렉트를 받지 않도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->