### PR TITLE
fix: 티켓팅 설명 줄바꿈 가능하게 변경

### DIFF
--- a/src/features/ticketing/admin/components/InputBlock.tsx
+++ b/src/features/ticketing/admin/components/InputBlock.tsx
@@ -10,7 +10,12 @@ export default function InputBlock({
   placeholder,
   type = 'text',
   withIcon,
+  multiline,
 }: InputBlockProps) {
+  const fieldClass = `w-full rounded-[5px] border border-gray-200 bg-white text-sm px-3 py-3 outline-none placeholder:text-gray-400 font-normal ${
+    withIcon ? 'pl-9' : ''
+  }`;
+
   return (
     <section className="space-y-2 w-full ">
       <p className="text-sm font-medium">{label}</p>
@@ -28,16 +33,25 @@ export default function InputBlock({
             </svg>
           </span>
         )}
-        <input
-          name={name}
-          value={value}
-          onChange={onChange}
-          type={type}
-          placeholder={placeholder}
-          className={`w-full rounded-[5px] border border-gray-200 bg-white text-sm px-3 py-3 outline-none placeholder:text-gray-400 font-normal ${
-            withIcon ? 'pl-9' : ''
-          }`}
-        />
+        {multiline ? (
+          <textarea
+            name={name}
+            value={value}
+            onChange={onChange}
+            placeholder={placeholder}
+            rows={5}
+            className={`${fieldClass} min-h-[120px] resize-y`}
+          />
+        ) : (
+          <input
+            name={name}
+            value={value}
+            onChange={onChange}
+            type={type}
+            placeholder={placeholder}
+            className={fieldClass}
+          />
+        )}
       </div>
     </section>
   );

--- a/src/features/ticketing/admin/pages/CreateEventPage.tsx
+++ b/src/features/ticketing/admin/pages/CreateEventPage.tsx
@@ -30,7 +30,9 @@ export default function CreateEventPage() {
   };
 
 
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
     const { name, value } = e.target;
 
     let newValue: string | number = value;
@@ -257,6 +259,7 @@ export default function CreateEventPage() {
                     placeholder="내용을 입력하세요."
                     value={form.description ?? ''}
                     onChange={handleChange}
+                    multiline
                 />
 
                 <CommonBtn text='생성하기' status={isFormValid? 1 : 0} onClick={handleSubmit}></CommonBtn>

--- a/src/features/ticketing/admin/pages/EditEventPage.tsx
+++ b/src/features/ticketing/admin/pages/EditEventPage.tsx
@@ -35,7 +35,7 @@ export default function EditEventPage() {
             eventTime: parseBackendDateToLocalDateTime(data.eventTime),
             eventEndTime: parseBackendDateToLocalDateTime(data.eventEndTime),
             locationInfo: data.locationInfo,
-            campus: data.campus == "SONGDO_CAMPUS" ? '성도 캠퍼스' : '미추가 캠퍼스',
+            campus: data.campus == "SONGDO_CAMPUS" ? '송도 캠퍼스' : '미추홀 캠퍼스',
             target: data.target,
             stock: data.currentQuantity,
             promotionLink: data.promotionLink,
@@ -88,7 +88,9 @@ export default function EditEventPage() {
   };
 
 
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
     const { name, value } = e.target;
 
     let newValue: string | number = value;
@@ -218,7 +220,7 @@ export default function EditEventPage() {
                 
                  {/* 제목 */}
                 <InputBlock
-                  label="제목"
+                  label="행사명"
                   name="title"
                   placeholder="내용을 입력해주세요"
                   value={form.title ?? ''}
@@ -235,9 +237,9 @@ export default function EditEventPage() {
                   withIcon
                 />
 
-                {/* 종시 */}
+                {/* 일시 */}
                 <InputBlock
-                  label="종시"
+                  label="일시"
                   name="eventEndTime"
                   type="datetime-local"
                   value={form.eventEndTime ?? ''}
@@ -259,12 +261,12 @@ export default function EditEventPage() {
                   name="campus"
                   value={form.campus ?? ''}
                   onChange={handleSelectChange}
-                  defaultValue={'성도 캠퍼스'}
+                  defaultValue={'송도 캠퍼스'}
                   className="w-full rounded-[5px] border border-gray-200 bg-white text-sm px-3 py-3 outline-none placeholder:text-gray-400 font-normal"
                 >
                   <option value="">캠퍼스를 선택해주세요</option>
-                  <option value="성도 캠퍼스">성도 캠퍼스</option>
-                  <option value="미추가 캠퍼스">미추가 캠퍼스</option>
+                  <option value="송도 캠퍼스">송도 캠퍼스</option>
+                  <option value="미추홀 캠퍼스">미추홀 캠퍼스</option>
                 </select>
 
 
@@ -313,6 +315,7 @@ export default function EditEventPage() {
                   placeholder="내용을 입력해주세요"
                   value={form.description ?? ''}
                   onChange={handleChange}
+                  multiline
                 />
                 
                 <CommonBtn text='수정하기' status={1} onClick={handleSubmit}></CommonBtn>

--- a/src/features/ticketing/admin/types.ts
+++ b/src/features/ticketing/admin/types.ts
@@ -5,8 +5,12 @@ export type InputBlockProps = {
   label: string;
   name: keyof CreateTicketEventRequest;
   value: string | number;
-  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  onChange: (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => void;
   placeholder?: string;
   type?: string;
   withIcon?: boolean;
+  /** true면 textarea로 렌더 (행사 설명 등 줄바꿈 입력) */
+  multiline?: boolean;
 };

--- a/src/features/ticketing/components/event/EventDetailInfoPanel.tsx
+++ b/src/features/ticketing/components/event/EventDetailInfoPanel.tsx
@@ -40,7 +40,7 @@ export function EventDetailInfoPanel({
             <span className="font-semibold">티켓팅 시작 시간:</span>{' '}
             {convertToKoreanDate(eventData.eventTime)}
           </div>
-          <div className="text-black/50 self-center mt-[18px]">
+          <div className="text-black/50 self-center mt-[18px] whitespace-pre-wrap break-words">
             {eventData.description}
           </div>
           <a


### PR DESCRIPTION
### 🔥 작업 내용
- 티켓팅 설명 줄바꿈 가능하게 변경


파일 | 내용
-- | --
admin/types.ts | InputBlockProps에 multiline?: boolean, onChange를 input \| textarea 이벤트로 확장
admin/components/InputBlock.tsx | multiline이면 <textarea> (rows={5}, min-h, resize-y)
CreateEventPage.tsx / EditEventPage.tsx | 행사 설명에 multiline, handleChange 타입 조정
EventDetailInfoPanel.tsx | 설명 영역에 whitespace-pre-wrap break-words로 저장된 \n을 화면에서 줄바꿈으로 표시


### 🤔 추후 작업 사항
- 티켓팅 유저정보 관련 플로우 논의
- 게시글 디자인 수정

### 🔗 이슈
- #369 

### 📸 피그마 스크린샷 or 기능 GIF
<img width="378" height="760" alt="image" src="https://github.com/user-attachments/assets/843f4999-f027-4d05-a7e8-05a1c6b2b8b0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 행사 설명 필드에서 여러 줄 텍스트 입력 지원 추가

* **버그 수정**
  * 캠퍼스 이름 표시 오류 수정
  * 행사 설명 텍스트의 줄바꿈 및 공백 처리 개선

* **개선 사항**
  * 행사 편집 페이지 필드 레이블 명확화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->